### PR TITLE
Fix admin login and task creation

### DIFF
--- a/src/main/java/ru/tz1/taskTracker/security/SecurityConfig.java
+++ b/src/main/java/ru/tz1/taskTracker/security/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // Настраиваем авторизацию запросов
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/auth/**", "/favicon.ico", "/error").permitAll()
+                        .requestMatchers("/api/auth/**", "/favicon.ico", "/error",
+                                "/mainPage", "/new", "/image.png").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/templates/authenticationPage.html
+++ b/src/main/resources/templates/authenticationPage.html
@@ -109,8 +109,7 @@
 
             alert('Вход выполнен успешно!');
 
-            // Вызываем fetchProtectedResource для получения задач
-            fetchProtectedResource();
+            window.location.href = '/mainPage';
         })
         .catch(error => {
             console.error("Error during login:", error);
@@ -118,59 +117,10 @@
         });
     });
 
-    // Функция для получения токена
+    // Возвращаем сохранённый токен
     function getToken() {
         return localStorage.getItem('token');
     }
-
-    // Функция для выполнения защищённого запроса
-    function fetchProtectedResource() {
-        const token = getToken();
-        console.log("Fetching with token:", token);
-        if (!token) {
-            console.error("Token not found.");
-            alert("Please log in again.");
-            window.location.href = '/api/auth/login';
-            return;
-        }
-
-        fetch('/tasks', {
-            method: 'GET',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
-        })
-        .then(response => {
-            console.log("Response status for /tasks:", response.status);
-            if (response.ok) {
-                return response.json();
-            } else {
-                return response.json().then(data => {
-                    console.error("Error response:", data);
-                    throw new Error(data.message || "Access denied. Please log in again.");
-                });
-            }
-        })
-        .then(data => {
-            const redirectUrl = data.redirectUrl || '/mainPage';
-            console.log("Redirect URL:", redirectUrl);
-            window.location.href = `${redirectUrl}?token=${token}`;
-        })
-        .catch(error => {
-            console.error("Error fetching protected resource:", error);
-            alert(error.message);
-            window.location.href = '/api/auth/login';
-        });
-    }
-
-    // Проверяем, если мы уже на странице логина
-    window.onload = function() {
-        const token = getToken();
-        if (token && window.location.pathname !== '/api/auth/login') {
-            fetchProtectedResource();
-        }
-    };
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/mainPage.html
+++ b/src/main/resources/templates/mainPage.html
@@ -151,8 +151,12 @@
 
     // Асинхронная функция для удаления задачи
     async function deleteTask(id) {
+        const token = localStorage.getItem('token');
         const response = await fetch(`/tasks/${id}`, {
-            method: 'DELETE' // Выполняем DELETE-запрос для удаления задачи по ID
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
         });
 
         if (response.ok) {
@@ -164,7 +168,12 @@
 
     // Асинхронная функция для редактирования задачи
     async function editTask(id) {
-        const response = await fetch(`/tasks/${id}`);
+        const token = localStorage.getItem('token');
+        const response = await fetch(`/tasks/${id}`, {
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        });
         if (!response.ok) {
             alert('Ошибка при загрузке задачи');
             return;
@@ -257,10 +266,12 @@
 
         console.log('Updating task with data:', updatedTask); // Логируем данные перед отправкой на сервер
 
+        const token = localStorage.getItem('token');
         const response = await fetch(`/tasks/${id}`, {
             method: 'PUT',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
             },
             body: JSON.stringify(updatedTask)
         });

--- a/src/main/resources/templates/newTaskForm.html
+++ b/src/main/resources/templates/newTaskForm.html
@@ -155,10 +155,12 @@
         console.log("Создаем новую задачу:", newTask); // Логируем объект задачи
 
         // Отправляем POST-запрос на создание задачи
+        const token = localStorage.getItem('token');
         fetch("/tasks", {
             method: "POST",
             headers: {
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`
             },
             body: JSON.stringify(newTask)
         })

--- a/src/main/resources/templates/newTaskFromForAdmin.html
+++ b/src/main/resources/templates/newTaskFromForAdmin.html
@@ -172,10 +172,12 @@
         console.log("Создаем новую задачу:", newTask); // Логируем объект задачи
 
         // Отправляем POST-запрос на создание задачи
+        const token = localStorage.getItem('token');
         fetch("/tasks", {
             method: "POST",
             headers: {
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${token}`
             },
             body: JSON.stringify(newTask)
         })


### PR DESCRIPTION
## Summary
- relax security so task pages don't need JWT header
- simplify login success redirect
- pass JWT token in all task-related fetch requests

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684836aee2e08327b8af83ea1a04c822